### PR TITLE
✅ refresh token 엔드포인트 기능 추가 외 2건

### DIFF
--- a/src/main/java/com/encore/playground/domain/comment/controller/CommentAPIController.java
+++ b/src/main/java/com/encore/playground/domain/comment/controller/CommentAPIController.java
@@ -39,8 +39,11 @@ public class CommentAPIController {
     @Parameter(name="feedId", description="피드 글번호", example="1", required = true)
     @GetMapping("/list/{feedId}")
     public Slice<CommentListDto> getCommentsInFeed(@PathVariable Long feedId, HttpServletRequest request, @PageableDefault(size=10) Pageable pageable) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        return commentService.getCommentsInFeed(CommentReadDto.builder().feedId(feedId).build(), memberIdDto, pageable);
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            return commentService.getCommentsInFeed(CommentReadDto.builder().feedId(feedId).build(), memberIdDto, pageable);
+        } else
+            return null;
     }
 
 
@@ -59,8 +62,10 @@ public class CommentAPIController {
     )
     @PostMapping(value = "/write")
     public void write(@RequestBody CommentWriteDto commentWriteDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        commentService.writeComment(commentWriteDto, memberIdDto);
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            commentService.writeComment(commentWriteDto, memberIdDto);
+        }
     }
 
     /**
@@ -77,25 +82,28 @@ public class CommentAPIController {
     )
     @PostMapping(value = "/modify")
     public ResponseEntity<?> modify(@RequestBody CommentModifyDto commentModifyDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        if (commentService.isCommentWriter(commentModifyDto.getId(), memberIdDto)) {
-            commentService.modifyComment(commentModifyDto, memberIdDto);
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.COMMENT_MODIFY
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.UNAUTHORIZED,
-                            ResponseMessage.COMMENT_MODIFY_FAILED
-                    ),
-                    HttpStatus.UNAUTHORIZED
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            if (commentService.isCommentWriter(commentModifyDto.getId(), memberIdDto)) {
+                commentService.modifyComment(commentModifyDto, memberIdDto);
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.COMMENT_MODIFY
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.UNAUTHORIZED,
+                                ResponseMessage.COMMENT_MODIFY_FAILED
+                        ),
+                        HttpStatus.UNAUTHORIZED
+                );
+            }
+        } else
+            return null;
     }
 
     /**
@@ -111,24 +119,27 @@ public class CommentAPIController {
     )
     @PostMapping(value = "/delete")
     public ResponseEntity<?> delete(@RequestBody CommentDeleteDto commentDeleteDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        if (commentService.isCommentWriter(commentDeleteDto.getId(), memberIdDto)) {
-            commentService.deleteComment(commentDeleteDto, memberIdDto);
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.COMMENT_DELETE
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.UNAUTHORIZED,
-                            ResponseMessage.COMMENT_DELETE_FAILED
-                    ),
-                    HttpStatus.UNAUTHORIZED
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            if (commentService.isCommentWriter(commentDeleteDto.getId(), memberIdDto)) {
+                commentService.deleteComment(commentDeleteDto, memberIdDto);
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.COMMENT_DELETE
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.UNAUTHORIZED,
+                                ResponseMessage.COMMENT_DELETE_FAILED
+                        ),
+                        HttpStatus.UNAUTHORIZED
+                );
+            }
+        } else
+            return null;
     }
 }

--- a/src/main/java/com/encore/playground/domain/feed/controller/FeedAPIController.java
+++ b/src/main/java/com/encore/playground/domain/feed/controller/FeedAPIController.java
@@ -40,8 +40,11 @@ public class FeedAPIController {
     @Operation(summary = "피드 메인페이지", description = "메인 페이지 접속 시 피드 목록을 반환한다.")
     @GetMapping(value = "/list")
     public Slice<FeedListDto> feedMain(HttpServletRequest request, @PageableDefault(size=10) Pageable pageable) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        return feedService.feedPage(memberIdDto, pageable);
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            return feedService.feedPage(memberIdDto, pageable);
+        } else
+            return null;
     }
 
     /**
@@ -56,31 +59,34 @@ public class FeedAPIController {
     @Parameter(name = "id", description = "피드 글 번호", example = "1", required = true)
     @GetMapping(value = "/view/{id}")
     public ResponseEntity<?> getFeed(@PathVariable Long id, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        HashMap<String, Object> feedAndComments = new HashMap<>();
-        FeedListDto feedListDto = feedService.getFeed(id);
-        feedAndComments.put("feed", feedListDto);
-        feedAndComments.put("comments",
-                commentService.getCommentsInFeed(
-                        CommentReadDto.builder().feedId(id).build(),
-                        memberIdDto,
-                        Pageable.unpaged()
-                )
-        );
-        String responseMessage = "";
-        if (feedService.isFeedWriter(feedListDto.getId(), memberIdDto)) {
-            responseMessage = ResponseMessage.FEED_DETAIL_SUCCESS;
-        } else {
-            responseMessage = ResponseMessage.FEED_DETAIL_FAILED;
-        }
-        return new ResponseEntity<>(
-                DefaultResponse.res(
-                        StatusCode.OK,
-                        responseMessage,
-                        feedAndComments
-                ),
-                HttpStatus.OK
-        );
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            HashMap<String, Object> feedAndComments = new HashMap<>();
+            FeedListDto feedListDto = feedService.getFeed(id);
+            feedAndComments.put("feed", feedListDto);
+            feedAndComments.put("comments",
+                    commentService.getCommentsInFeed(
+                            CommentReadDto.builder().feedId(id).build(),
+                            memberIdDto,
+                            Pageable.unpaged()
+                    )
+            );
+            String responseMessage = "";
+            if (feedService.isFeedWriter(feedListDto.getId(), memberIdDto)) {
+                responseMessage = ResponseMessage.FEED_DETAIL_SUCCESS;
+            } else {
+                responseMessage = ResponseMessage.FEED_DETAIL_FAILED;
+            }
+            return new ResponseEntity<>(
+                    DefaultResponse.res(
+                            StatusCode.OK,
+                            responseMessage,
+                            feedAndComments
+                    ),
+                    HttpStatus.OK
+            );
+        } else
+            return null;
     }
 
     @GetMapping(value = "/test")
@@ -111,8 +117,10 @@ public class FeedAPIController {
     )
     @PostMapping(value = "/write")
     public void write(@RequestBody FeedWriteDto feedWriteDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        feedService.write(feedWriteDto, memberIdDto);
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            feedService.write(feedWriteDto, memberIdDto);
+        }
     }
 
     /**
@@ -133,25 +141,28 @@ public class FeedAPIController {
     )
     @PostMapping(value = "/modify")
     public ResponseEntity<?> modify(@RequestBody FeedModifyDto feedModifyDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        if (feedService.isFeedWriter(feedModifyDto.getId(), memberIdDto)){
-            feedService.modify(feedModifyDto, memberIdDto);
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.FEED_MODIFY_SUCCESS
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.UNAUTHORIZED,
-                            ResponseMessage.FEED_MODIFY_FAILED
-                    ),
-                    HttpStatus.UNAUTHORIZED
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            if (feedService.isFeedWriter(feedModifyDto.getId(), memberIdDto)) {
+                feedService.modify(feedModifyDto, memberIdDto);
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.FEED_MODIFY_SUCCESS
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.UNAUTHORIZED,
+                                ResponseMessage.FEED_MODIFY_FAILED
+                        ),
+                        HttpStatus.UNAUTHORIZED
+                );
+            }
+        } else
+            return null;
     }
 
     /**
@@ -171,24 +182,27 @@ public class FeedAPIController {
     )
     @PostMapping(value = "/delete")
     public ResponseEntity<?> delete(@RequestBody FeedDeleteDto feedDeleteDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        if (feedService.isFeedWriter(feedDeleteDto.getId(), memberIdDto)){
-            feedService.delete(feedDeleteDto, memberIdDto);
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.FEED_DELETE_SUCCESS
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.UNAUTHORIZED,
-                            ResponseMessage.FEED_DELETE_FAILED
-                    ),
-                    HttpStatus.UNAUTHORIZED
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            if (feedService.isFeedWriter(feedDeleteDto.getId(), memberIdDto)) {
+                feedService.delete(feedDeleteDto, memberIdDto);
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.FEED_DELETE_SUCCESS
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.UNAUTHORIZED,
+                                ResponseMessage.FEED_DELETE_FAILED
+                        ),
+                        HttpStatus.UNAUTHORIZED
+                );
+            }
+        } else
+            return null;
     }
 }

--- a/src/main/java/com/encore/playground/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/encore/playground/domain/follow/controller/FollowController.java
@@ -16,13 +16,17 @@ public class FollowController {
 
     @PostMapping("/follow")
     public void follow(@RequestBody FollowGetIdDto followGetIdDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        followService.follow(followGetIdDto, memberIdDto);
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            followService.follow(followGetIdDto, memberIdDto);
+        }
     }
 
     @PostMapping("/unfollow")
     public void unfollow(@RequestBody FollowGetIdDto followGetIdDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        followService.unfollow(followGetIdDto, memberIdDto);
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            followService.unfollow(followGetIdDto, memberIdDto);
+        }
     }
 }

--- a/src/main/java/com/encore/playground/domain/likes/controller/LikesController.java
+++ b/src/main/java/com/encore/playground/domain/likes/controller/LikesController.java
@@ -18,14 +18,18 @@ public class LikesController {
 
     @PostMapping("/likes")
     public void likes(@RequestBody LikesGetIdDto likesGetIdDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        likesService.likes(likesGetIdDto, memberIdDto);
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            likesService.likes(likesGetIdDto, memberIdDto);
+        }
     }
 
     @PostMapping("/likesCancel")
     public void likesCancel(@RequestBody LikesGetIdDto likesGetIdDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        likesService.likesCancel(likesGetIdDto, memberIdDto);
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            likesService.likesCancel(likesGetIdDto, memberIdDto);
+        }
     }
 
 

--- a/src/main/java/com/encore/playground/domain/member/dto/MemberPasswordDto.java
+++ b/src/main/java/com/encore/playground/domain/member/dto/MemberPasswordDto.java
@@ -8,6 +8,5 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberPasswordDto {
-    private String userid;
     private String password;
 }

--- a/src/main/java/com/encore/playground/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/encore/playground/domain/mypage/controller/MyPageController.java
@@ -18,8 +18,11 @@ public class MyPageController {
 
     @GetMapping("/mypage")
     public MyPageDto myPageMain(HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        return myPageService.myPage(memberIdDto);
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            return myPageService.myPage(memberIdDto);
+        } else
+            return null;
     }
 
 }

--- a/src/main/java/com/encore/playground/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/encore/playground/domain/notice/controller/NoticeController.java
@@ -15,7 +15,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -26,123 +25,138 @@ public class NoticeController {
 
     @GetMapping("/notice")
     public ResponseEntity<?> noticeMain(HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        MemberGetRoleDto memberRoleDto = (MemberGetRoleDto) request.getAttribute("memberRoleDto");
-        if (memberRoleDto.getRole().equals("ROLE_ADMIN")) {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.NOTICE_ADMIN_ACCESS,
-                            noticeService.noticeList()
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.NOTICE_USER_ACCESS,
-                            noticeService.noticeList()
-                    ),
-                    HttpStatus.OK
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            MemberGetRoleDto memberRoleDto = (MemberGetRoleDto) request.getAttribute("memberRoleDto");
+            if (memberRoleDto.getRole().equals("ROLE_ADMIN")) {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.NOTICE_ADMIN_ACCESS,
+                                noticeService.noticeList()
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.NOTICE_USER_ACCESS,
+                                noticeService.noticeList()
+                        ),
+                        HttpStatus.OK
+                );
+            }
+        } else
+            return null;
     }
     @GetMapping("/notice/view/{id}")
     public ResponseEntity<?> noticeRead(@PathVariable Long id, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        if (noticeService.isNoticeWriter(id, memberIdDto)) {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.NOTICE_WRITER_ACCESS,
-                            noticeService.readNotice(id, memberIdDto)
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.NOTICE_WRITER_ACCESS_FAILED,
-                            noticeService.readNotice(id, memberIdDto)
-                    ),
-                    HttpStatus.OK
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            if (noticeService.isNoticeWriter(id, memberIdDto)) {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.NOTICE_WRITER_ACCESS,
+                                noticeService.readNotice(id, memberIdDto)
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.NOTICE_WRITER_ACCESS_FAILED,
+                                noticeService.readNotice(id, memberIdDto)
+                        ),
+                        HttpStatus.OK
+                );
+            }
+        } else
+            return null;
     }
 
 
     @PostMapping("/notice/write")
     public ResponseEntity<?> noticeWrite(@RequestBody NoticeWriteDto noticeWriteDto, HttpServletRequest request) {
-        MemberGetRoleDto memberRoleDto = (MemberGetRoleDto) request.getAttribute("memberRoleDto");
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        if (memberRoleDto.getRole().equals("ROLE_ADMIN")) {
-            noticeService.writeNotice(noticeWriteDto, memberIdDto);
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.NOTICE_ADMIN_ACCESS
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.UNAUTHORIZED,
-                            ResponseMessage.NOTICE_USER_ACCESS,
-                            noticeService.noticeList()
-                    ),
-                    HttpStatus.UNAUTHORIZED
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetRoleDto memberRoleDto = (MemberGetRoleDto) request.getAttribute("memberRoleDto");
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            if (memberRoleDto.getRole().equals("ROLE_ADMIN")) {
+                noticeService.writeNotice(noticeWriteDto, memberIdDto);
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.NOTICE_ADMIN_ACCESS
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.UNAUTHORIZED,
+                                ResponseMessage.NOTICE_USER_ACCESS,
+                                noticeService.noticeList()
+                        ),
+                        HttpStatus.UNAUTHORIZED
+                );
+            }
+        } else
+            return null;
     }
 
 
     @PostMapping("/notice/modify")
     public ResponseEntity<?> noticeModify(@RequestBody NoticeModifyDto noticeModifyDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        if (noticeService.isNoticeWriter(noticeModifyDto.getId(), memberIdDto)) {
-            noticeService.modifyNotice(noticeModifyDto, memberIdDto);
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.NOTICE_WRITER_ACCESS
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.UNAUTHORIZED,
-                            ResponseMessage.NOTICE_WRITER_ACCESS_FAILED
-                    ),
-                    HttpStatus.UNAUTHORIZED
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            if (noticeService.isNoticeWriter(noticeModifyDto.getId(), memberIdDto)) {
+                noticeService.modifyNotice(noticeModifyDto, memberIdDto);
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.NOTICE_WRITER_ACCESS
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.UNAUTHORIZED,
+                                ResponseMessage.NOTICE_WRITER_ACCESS_FAILED
+                        ),
+                        HttpStatus.UNAUTHORIZED
+                );
+            }
 
+        } else
+            return null;
     }
 
     @PostMapping("/notice/delete")
     public ResponseEntity<?> noticeDelete(@RequestBody NoticeGetIdDto noticeGetIdDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        if (noticeService.isNoticeWriter(noticeGetIdDto.getId(), memberIdDto)) {
-            noticeService.deleteNotice(noticeGetIdDto, memberIdDto);
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.NOTICE_DELETE_SUCCESS
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.UNAUTHORIZED,
-                            ResponseMessage.NOTICE_DELETE_FAILED
-                    ),
-                    HttpStatus.UNAUTHORIZED
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            if (noticeService.isNoticeWriter(noticeGetIdDto.getId(), memberIdDto)) {
+                noticeService.deleteNotice(noticeGetIdDto, memberIdDto);
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.NOTICE_DELETE_SUCCESS
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.UNAUTHORIZED,
+                                ResponseMessage.NOTICE_DELETE_FAILED
+                        ),
+                        HttpStatus.UNAUTHORIZED
+                );
+            }
+        } else
+            return null;
     }
 }

--- a/src/main/java/com/encore/playground/domain/qna/controller/AnswerController.java
+++ b/src/main/java/com/encore/playground/domain/qna/controller/AnswerController.java
@@ -28,9 +28,12 @@ public class AnswerController {
      */
     @PostMapping("/answer/list")
     private List<AnswerListDto> answerList(@RequestBody QuestionGetIdDto questionGetIdDto, HttpServletRequest request) {
-        Long questionId = questionGetIdDto.getId();
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        return answerService.getAnswerList(questionId, memberIdDto);
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            Long questionId = questionGetIdDto.getId();
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            return answerService.getAnswerList(questionId, memberIdDto);
+        } else
+            return null;
     }
 
 
@@ -42,8 +45,10 @@ public class AnswerController {
      */
     @PostMapping("/answer/write")
     private void writeAnswer(@RequestBody AnswerWriteDto answerWriteDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        answerService.createAnswer(answerWriteDto, memberIdDto);
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            answerService.createAnswer(answerWriteDto, memberIdDto);
+        }
     }
 
     /**
@@ -54,25 +59,28 @@ public class AnswerController {
      */
     @PostMapping("/answer/modify")
     private ResponseEntity<?> modifyAnswer(@RequestBody AnswerModifyDto answerModifyDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        if (answerService.isAnswerWriter(answerModifyDto.getId(), memberIdDto)) {
-            answerService.modifyAnswer(answerModifyDto, memberIdDto);
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.ANSWER_MODIFY_SUCCESS
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.UNAUTHORIZED,
-                            ResponseMessage.ANSWER_MODIFY_FAILED
-                    ),
-                    HttpStatus.UNAUTHORIZED
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            if (answerService.isAnswerWriter(answerModifyDto.getId(), memberIdDto)) {
+                answerService.modifyAnswer(answerModifyDto, memberIdDto);
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.ANSWER_MODIFY_SUCCESS
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.UNAUTHORIZED,
+                                ResponseMessage.ANSWER_MODIFY_FAILED
+                        ),
+                        HttpStatus.UNAUTHORIZED
+                );
+            }
+        } else
+            return null;
     }
 
     /**
@@ -84,24 +92,27 @@ public class AnswerController {
 
     @PostMapping("/answer/delete")
     private ResponseEntity<?> deleteAnswer(@RequestBody AnswerDeleteDto answerDeleteDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        if (answerService.isAnswerWriter(answerDeleteDto.getId(), memberIdDto)) {
-            answerService.deleteAnswer(answerDeleteDto, memberIdDto);
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.ANSWER_DELETE_SUCCESS
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.UNAUTHORIZED,
-                            ResponseMessage.ANSWER_DELETE_FAILED
-                    ),
-                    HttpStatus.UNAUTHORIZED
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            if (answerService.isAnswerWriter(answerDeleteDto.getId(), memberIdDto)) {
+                answerService.deleteAnswer(answerDeleteDto, memberIdDto);
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.ANSWER_DELETE_SUCCESS
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.UNAUTHORIZED,
+                                ResponseMessage.ANSWER_DELETE_FAILED
+                        ),
+                        HttpStatus.UNAUTHORIZED
+                );
+            }
+        } else
+            return null;
     }
 }

--- a/src/main/java/com/encore/playground/domain/qna/controller/QuestionController.java
+++ b/src/main/java/com/encore/playground/domain/qna/controller/QuestionController.java
@@ -34,81 +34,92 @@ public class QuestionController {
 
     @GetMapping("/question/view/{id}")
     public ResponseEntity<?> viewQuestion(@PathVariable Long id, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        QuestionDto questionDto = questionService.readQuestion(id, memberIdDto);
-        Map<String, QuestionDto> questionDtoMap = new HashMap<>();
-        questionDtoMap.put("question", questionDto);
-        if (questionService.isQuestionWriter(id, memberIdDto)) {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.QUESTION_WRITER_ACCESS,
-                            questionDtoMap
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.QUESTION_WRITER_ACCESS_FAILED,
-                            questionDtoMap
-                    ),
-                    HttpStatus.OK
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            QuestionDto questionDto = questionService.readQuestion(id, memberIdDto);
+            Map<String, QuestionDto> questionDtoMap = new HashMap<>();
+            questionDtoMap.put("question", questionDto);
+            if (questionService.isQuestionWriter(id, memberIdDto)) {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.QUESTION_WRITER_ACCESS,
+                                questionDtoMap
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.QUESTION_WRITER_ACCESS_FAILED,
+                                questionDtoMap
+                        ),
+                        HttpStatus.OK
+                );
+            }
+        } else
+            return null;
     }
 
     @PostMapping("/question/write")
     public void questionWrite(@RequestBody QuestionWriteDto questionWriteDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        questionService.writeQuestion(questionWriteDto, memberIdDto);
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            questionService.writeQuestion(questionWriteDto, memberIdDto);
+        }
     }
 
     @PostMapping("/question/modify")
     public ResponseEntity<?> questionModify(@RequestBody QuestionModifyDto questionModifyDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        if (questionService.isQuestionWriter(questionModifyDto.getId(), memberIdDto)) {
-            questionService.modifyQuestion(questionModifyDto, memberIdDto);
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.QNA_MODIFY_SUCCESS
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.UNAUTHORIZED,
-                            ResponseMessage.QNA_MODIFY_FAILED
-                    ),
-                    HttpStatus.UNAUTHORIZED
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            if (questionService.isQuestionWriter(questionModifyDto.getId(), memberIdDto)) {
+                questionService.modifyQuestion(questionModifyDto, memberIdDto);
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.QNA_MODIFY_SUCCESS
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.UNAUTHORIZED,
+                                ResponseMessage.QNA_MODIFY_FAILED
+                        ),
+                        HttpStatus.UNAUTHORIZED
+                );
+            }
+        } else
+            return null;
     }
 
 
     @PostMapping("/question/delete")
     public ResponseEntity<?> questionDelete(@RequestBody QuestionGetIdDto questionIdDto, HttpServletRequest request) {
-        MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
-        if (questionService.isQuestionWriter(questionIdDto.getId(), memberIdDto)) {
-            questionService.deleteQuestion(questionIdDto, memberIdDto);
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.OK,
-                            ResponseMessage.QNA_DELETE_SUCCESS
-                    ),
-                    HttpStatus.OK
-            );
-        } else {
-            return new ResponseEntity<>(
-                    DefaultResponse.res(
-                            StatusCode.UNAUTHORIZED,
-                            ResponseMessage.QNA_DELETE_FAILED
-                    ),
-                    HttpStatus.UNAUTHORIZED
-            );
-        }
+        if (request.getAttribute("AccessTokenValidation").equals("true")) {
+            MemberGetMemberIdDto memberIdDto = (MemberGetMemberIdDto) request.getAttribute("memberIdDto");
+            if (questionService.isQuestionWriter(questionIdDto.getId(), memberIdDto)) {
+                questionService.deleteQuestion(questionIdDto, memberIdDto);
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.OK,
+                                ResponseMessage.QNA_DELETE_SUCCESS
+                        ),
+                        HttpStatus.OK
+                );
+            } else {
+                return new ResponseEntity<>(
+                        DefaultResponse.res(
+                                StatusCode.UNAUTHORIZED,
+                                ResponseMessage.QNA_DELETE_FAILED
+                        ),
+                        HttpStatus.UNAUTHORIZED
+                );
+            }
+        } else
+            return null;
     }
 }

--- a/src/main/java/com/encore/playground/global/controller/JwtController.java
+++ b/src/main/java/com/encore/playground/global/controller/JwtController.java
@@ -1,0 +1,45 @@
+package com.encore.playground.global.controller;
+
+import com.encore.playground.global.api.DefaultResponse;
+import com.encore.playground.global.api.ResponseMessage;
+import com.encore.playground.global.api.StatusCode;
+import com.encore.playground.global.dto.RefreshTokenValidateDto;
+import com.encore.playground.global.jwt.JwtTokenProvider;
+import com.encore.playground.global.service.TokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@RestController
+public class JwtController {
+
+    private final TokenService tokenService;
+    private final JwtTokenProvider jwtTokenProvider;
+    @PostMapping("/refreshtoken")
+    public ResponseEntity<?> getRefreshToken(HttpServletRequest request) {
+        System.out.println("request가 들어왔습니다. " + request);
+        System.out.println("request header의 값은 " + request.getHeader("refresh-token"));
+        RefreshTokenValidateDto refreshTokenDto = new RefreshTokenValidateDto(request.getHeader("refresh-token"));
+        System.out.println(refreshTokenDto.getRefreshToken());
+        if (tokenService.validateRefreshToken(refreshTokenDto)) {
+            String userid = jwtTokenProvider.getUserIdByRefreshToken(refreshTokenDto.getRefreshToken());
+            String roles = jwtTokenProvider.getMemberRoleByRefreshToken(refreshTokenDto.getRefreshToken());
+            System.out.println(userid);
+            System.out.println(roles);
+            String newAccessToken = "Bearer " + JwtTokenProvider.generateAccessToken(userid, roles).getAccessToken();
+            System.out.println("새롭게 발급된 access token 입니다. " + newAccessToken);
+            return new ResponseEntity<>(newAccessToken, HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(ResponseMessage.LOG_OUT, HttpStatus.NOT_ACCEPTABLE);
+        }
+    }
+}

--- a/src/main/java/com/encore/playground/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/encore/playground/global/jwt/JwtAuthenticationFilter.java
@@ -28,27 +28,27 @@ public class JwtAuthenticationFilter extends GenericFilter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-        // refresh token이 있는지 확인하고 존재하면 검증한다.
-        // 클라이언트에 unauthorized error code(401)을 보내서 request로 refresh token이 들어온다.
-        if (httpRequest.getHeader("refresh-token") != null){
-            System.out.println("[JwtAuthenticationFilter] ::: refreshToken이 존재합니다.");
-            // refresh token을 받아와서 검증한다.
-            System.out.println("[JwtAuthenticationFilter] ::: refreshToken을 검증합니다.");
-            // refresh token이 유효한 경우,
-            RefreshTokenValidateDto refreshTokenValidateDto = getRefreshToken(httpRequest);
-            if (tokenService.validateRefreshToken(refreshTokenValidateDto)) {
-                // 새로운 access token을 발급해서 보내준다.
-                // 수정 (refreshtoken으로 refreshtoken table의 memberId 가져오기)
-                String newAccessToken = tokenService.generateAccessToken(tokenService.getMemberIdFromRefreshToken(refreshTokenValidateDto)).getAccessToken();
-                httpResponse.addHeader("Authorization", "Bearer " + newAccessToken);
-                httpResponse.setStatus(HttpServletResponse.SC_OK);
-            } else {
-                // refresh token이 유효하지 않은 경우, 로그아웃 처리한다.
-                System.out.println("refresh token이 유효하지 않습니다.");
-                httpResponse.setHeader("responseMessage", ResponseMessage.LOG_OUT);
-                httpResponse.setStatus(HttpServletResponse.SC_NOT_ACCEPTABLE);
-            }
-        }
+//        // refresh token이 있는지 확인하고 존재하면 검증한다.
+//        // 클라이언트에 unauthorized error code(401)을 보내서 request로 refresh token이 들어온다.
+//        if (httpRequest.getHeader("refresh-token") != null){
+//            System.out.println("[JwtAuthenticationFilter] ::: refreshToken이 존재합니다.");
+//            // refresh token을 받아와서 검증한다.
+//            System.out.println("[JwtAuthenticationFilter] ::: refreshToken을 검증합니다.");
+//            // refresh token이 유효한 경우,
+//            RefreshTokenValidateDto refreshTokenValidateDto = getRefreshToken(httpRequest);
+//            if (tokenService.validateRefreshToken(refreshTokenValidateDto)) {
+//                // 새로운 access token을 발급해서 보내준다.
+//                // 수정 (refreshtoken으로 refreshtoken table의 memberId 가져오기)
+//                String newAccessToken = tokenService.generateAccessToken(tokenService.getMemberIdFromRefreshToken(refreshTokenValidateDto)).getAccessToken();
+//                httpResponse.addHeader("Authorization", "Bearer " + newAccessToken);
+//                httpResponse.setStatus(HttpServletResponse.SC_OK);
+//            } else {
+//                // refresh token이 유효하지 않은 경우, 로그아웃 처리한다.
+//                System.out.println("refresh token이 유효하지 않습니다.");
+//                httpResponse.setHeader("responseMessage", ResponseMessage.LOG_OUT);
+//                httpResponse.setStatus(HttpServletResponse.SC_NOT_ACCEPTABLE);
+//            }
+//        }
 
 
         // Header 부분에서 JWT 정보를 가져온다.
@@ -75,6 +75,7 @@ public class JwtAuthenticationFilter extends GenericFilter {
             System.out.println(memberGetMemberIdDto);
             MemberGetRoleDto memberGetRoleDto = MemberGetRoleDto.builder().role(jwtTokenProvider.getMemberRole(token)).build();
             System.out.println(memberGetRoleDto);// userid만 들어있는 dto를 request에 넣어주기
+            httpRequest.setAttribute("AccessTokenValidation", "true");
             httpRequest.setAttribute("memberIdDto", memberGetMemberIdDto);
             httpRequest.setAttribute("memberRoleDto", memberGetRoleDto);
 
@@ -86,6 +87,7 @@ public class JwtAuthenticationFilter extends GenericFilter {
             httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             httpResponse.setHeader("responseMessage", ResponseMessage.ACCESS_TOKEN_EXPIRED);
             System.out.println("[JwtAuthenticationFilter] ::: 토큰이 만료됐습니다.");
+            httpRequest.setAttribute("AccessTokenValidation", "false");
         }
 
         chain.doFilter(request, response);

--- a/src/main/java/com/encore/playground/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/encore/playground/global/jwt/JwtTokenProvider.java
@@ -99,8 +99,16 @@ public class JwtTokenProvider {
         return Jwts.parser().setSigningKey(JWT_ACCESS_TOKEN_SECRET).parseClaimsJws(token).getBody().getSubject();
     }
 
+    public String getUserIdByRefreshToken(String refreshToken) {
+        return Jwts.parser().setSigningKey(JWT_REFRESH_TOKEN_SECRET).parseClaimsJws(refreshToken).getBody().getSubject();
+    }
+
     public String getMemberRole(String token) {
         return (String) Jwts.parser().setSigningKey(JWT_ACCESS_TOKEN_SECRET).parseClaimsJws(token).getBody().get("roles");
+    }
+
+    public String getMemberRoleByRefreshToken(String refreshToken) {
+        return (String) Jwts.parser().setSigningKey(JWT_ACCESS_TOKEN_SECRET).parseClaimsJws(refreshToken).getBody().get("roles");
     }
 
 


### PR DESCRIPTION
**refresh token**
- 프론트엔드에서 access token이 만료됐을 때, refresh token을 보낼 수 있는 엔드포인트를 만들었다.
- 기존 JwtAuthenticationFilter에 존재하는 refresh token 관련 코드를 삭제했다.

**만료된 access token에 대한 처리**
- 모든 컨트롤러의 request를 param으로 받는 엔드포인트에 AccessTokenValidation을 검증하는 코드를 작성했다.

**memberAPIController**
- 다른 controller와 형식을 맞췄다.
- password 변경 엔드포인트에 param으로 request를 추가하며 기존에 사용하던 passworddto에서 userid 컬럼을 삭제했다. 

